### PR TITLE
fix: 🐛 Allow installing PyQt5 even if the license was not accepted

### DIFF
--- a/Code/setup_macos.py
+++ b/Code/setup_macos.py
@@ -7,7 +7,7 @@ for x in range(1,4):
         flag=flag | 0x01
         break
 for x in range(1,4):
-    if os.system("pip3 install PyQt5==5.15.2") == 0:
+    if os.system("pip3 install --config-settings --confirm-license= PyQt5==5.15.2") == 0:
         flag=flag | 0x02
         break
 for x in range(1,4):


### PR DESCRIPTION
Otherwise, the build will wait for a long time doing nothing and then fail on timeout.